### PR TITLE
Feat/more flexible colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,22 @@ import nl.attendi.attendispeechservice.components.attendimicrophone.AttendiMicro
 
 AttendiMicrophone(
     // We can use some general Compose modifiers here, such as `padding`, but some like
-    // `size` won't work. In general, check first whether `MicrophoneModifier` has a parameter
+    // `size` won't work. In general, check first whether `AttendiMicrophone` has a parameter
     // to change the aspect of the microphone that you want to change.
     modifier = Modifier
         .border(1.dp, pinkColor, RoundedCornerShape(percent = 50))
         .background(Color.White),
-    // Change aspects of the microphone's appearance, such as size and color,
-    // using the `microphoneModifier` parameter
-    microphoneModifier = MicrophoneModifier(size = 64.dp, color = pinkColor),
+    // Change the microphone's size
+    size = 64.dp,
+    // Change the microphone's color
+    colors = AttendiMicrophoneDefaults.colors(baseColor = myColor),
+    // Or do this if you need more control over the microphone's colors
+    // colors = AttendiMicrophoneDefaults.colors(
+    //     inactiveBackgroundColor = myColor,
+    //     inactiveForegroundColor = Color.White,
+    //     activeBackgroundColor = myColor,
+    //     activeForegroundColor = Color.White,
+    // ),
     // Add plugins if necessary. These extend the functionality of the microphone component.
     plugins = listOf(
         AttendiErrorPlugin(),
@@ -116,10 +124,6 @@ For more details on the `AttendiMicrophone`'s API, see its docstring.
 The `AttendiMicrophone` exposes two callbacks in its initializer: `onEvent` and `onResult`. The `onResult` callback can be called by plugins when they want to signal a result to the client when that result is in text (string) form. As seen in the example above, the text can be accessed by the client by providing a closure to the `onResult` parameter.
 
 The `onEvent` callback can be called by plugins when they want to signal a more general event to the client. Plugins can call `onEvent` and pass it an event name and a result object. The client can then listen for these events by providing a closure to the `onEvent` parameter. The client can then check the event name and the result object to determine what to do.
-
-## Styling
-
-The microphone component can be styled using the `microphoneModifier` parameter. See the `MicrophoneModifier`'s docstring for more details.
 
 ## Creating a plugin
 

--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendimicrophone/AttendiMicrophone.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendimicrophone/AttendiMicrophone.kt
@@ -16,7 +16,6 @@ package nl.attendi.attendispeechservice.components.attendimicrophone
 
 import AttendiMicrophoneColors
 import AttendiMicrophoneDefaults
-import MicrophoneModifier
 import MicrophoneOptionsVariant
 import MicrophoneSettings
 import android.Manifest
@@ -71,6 +70,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.min
 import androidx.compose.ui.unit.times
@@ -112,9 +112,9 @@ val LocalMicrophoneState =
  * Example:
  * ```kotlin
  * AttendiMicrophone(
- *  microphoneModifier = MicrophoneModifier(
- *    size = 64.dp, color = Color.Red, cornerRadius = 16.dp
- *  ),
+ *  size = 64.dp,
+ *  colors = AttendiMicrophoneDefaults.colors(baseColor = Color.Red),
+ *  cornerRadius = 16.dp,
  *  plugins = listOf(
  *    AttendiErrorPlugin(),
  *    AttendiTranscribePlugin()
@@ -125,10 +125,14 @@ val LocalMicrophoneState =
  * ```
  *
  * @param modifier While the modifier allows changing some visual properties of the contained components,
- * it is recommended to use the [microphoneModifier] instead, which contains styling options
+ * it is recommended to use this component's parameters instead where possible, which contains styling options
  * specific to the [AttendiMicrophone].
- * @param microphoneModifier Use this to change certain aspects of the microphone's appearance.
- * To see what properties can be changed, see [MicrophoneModifier].
+ * @param size Sets the width and height of the microphone. If showOptions is false,
+ * the width and height will be equal. If showOptions is true, the width will be twice the height.
+ * @param cornerRadius Sets the corner radius of the microphone. If not set, the button will have a
+ * RoundedCornerShape of 50 percent.
+ * @param colors Use this to change the colors of the microphone. To see what colors can be changed,
+ * see [AttendiMicrophoneDefaults.colors].
  * @param plugins Functionality can be added to this component through a plugin system.
  * See the [AttendiMicrophonePlugin] interface for more information.
  * @param silent By default, the component will play a sound when the recording is
@@ -154,7 +158,8 @@ val LocalMicrophoneState =
 @Composable
 fun AttendiMicrophone(
     modifier: Modifier = Modifier,
-    microphoneModifier: MicrophoneModifier = MicrophoneModifier(),
+    cornerRadius: Dp? = null,
+    size: Dp = 48.dp,
     colors: AttendiMicrophoneColors = AttendiMicrophoneDefaults.colors(),
     plugins: List<AttendiMicrophonePlugin> = listOf(),
     silent: Boolean = false,
@@ -166,7 +171,9 @@ fun AttendiMicrophone(
     val context = LocalContext.current
 
     val settings = MicrophoneSettings(
+        size = size,
         colors = colors,
+        cornerRadius = cornerRadius
     )
 
     // TODO: implement showOptions properly
@@ -176,9 +183,6 @@ fun AttendiMicrophone(
     } else {
         settings.showOptionsVariant = MicrophoneOptionsVariant.HIDDEN
     }
-
-    microphoneModifier.size?.let { settings.size = it }
-    microphoneModifier.cornerRadius?.let { settings.cornerRadius = it }
 
     // Bottom sheet
     val isOptionsMenuOpen = rememberSaveable { mutableStateOf(false) }

--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendimicrophone/AttendiMicrophoneSettings.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendimicrophone/AttendiMicrophoneSettings.kt
@@ -17,22 +17,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
-/**
- * Used to change aspects of the microphone's appearance.
- */
-data class MicrophoneModifier(
-    /**
-     *  Sets the width and height of the microphone. If showOptions is false, the width and height
-     *  will be equal. If showOptions is true, the width will be twice the height.
-     */
-    val size: Dp? = null,
-    /**
-     * Sets the corner radius of the microphone. If not set, the button will have a RoundedCornerShape
-     * of 50 percent.
-     */
-    val cornerRadius: Dp? = null
-)
-
 @Immutable
 data class AttendiMicrophoneColors internal constructor(
     val activeForegroundColor: Color,
@@ -71,7 +55,7 @@ object AttendiMicrophoneDefaults {
         inactiveForegroundColor: Color = baseColor,
         activeBackgroundColor: Color = baseColor,
         activeForegroundColor: Color = Color.White
-        ): AttendiMicrophoneColors =
+    ): AttendiMicrophoneColors =
         AttendiMicrophoneColors(
             inactiveBackgroundColor = inactiveBackgroundColor,
             inactiveForegroundColor = inactiveForegroundColor,

--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendimicrophone/plugins/closed/ReportingMethodPlugin.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendimicrophone/plugins/closed/ReportingMethodPlugin.kt
@@ -268,9 +268,7 @@ fun LinearReportingMethodView(
                     verticalArrangement = Arrangement.Bottom
                 ) {
                     AttendiMicrophone(
-                        // microphoneModifier = MicrophoneModifier(
-                        //     size = 58.0,
-                        // ),
+                        // size = 58.dp,
                         plugins = listOf(
                             AttendiTranscribePlugin(
                                 TranscribeAPIConfig(
@@ -406,9 +404,7 @@ fun LinearReportingMethodView(
                 Spacer(modifier = Modifier.weight(1f)) // This acts as the first button
                 Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
                     AttendiMicrophone(
-                        // microphoneModifier = MicrophoneModifier(
-                        //     size = 58.0,
-                        // ),
+                        // size = 58.0,
                         plugins = listOf(
                             AttendiTranscribePlugin(
                                 TranscribeAPIConfig(

--- a/attendispeechserviceexample/src/main/java/nl/attendi/attendispeechserviceexample/MainActivity.kt
+++ b/attendispeechserviceexample/src/main/java/nl/attendi/attendispeechserviceexample/MainActivity.kt
@@ -15,7 +15,6 @@
 package nl.attendi.attendispeechserviceexample
 
 import AttendiMicrophoneDefaults
-import MicrophoneModifier
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -244,7 +243,7 @@ fun HoveringMicrophoneScreen() {
                 modifier = Modifier
                     .border(1.dp, pinkColor, RoundedCornerShape(percent = 50))
                     .background(Color.White),
-                microphoneModifier = MicrophoneModifier(size = 64.dp),
+                size = 64.dp,
                 colors = AttendiMicrophoneDefaults.colors(
                     inactiveBackgroundColor = pinkColor,
                     inactiveForegroundColor = Color.White,


### PR DESCRIPTION
We add more flexibility by allowing the specification of more colors such
as `inactiveBackgroundColor`, `inactiveForegroundColor`, and `active...` counterparts.

We follow the Material jetpack Compose style to let parameters that
influence the appearance of the component be top-level components, as opposed
to putting them in a sub-object. This means that e.g. `size`, `cornerRadius`,
and `colors` are now parameters of the `AttendiMicrophone` itself.

This is a breaking change.