### PR TITLE
refactor: rollback adding onState parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,16 @@ AttendiMicrophone(
     plugins = listOf(
         AttendiErrorPlugin(),
         AttendiTranscribePlugin(apiConfig = exampleAPIConfig),
-    ),
-    // Use `onState` to access the microphone's state that exposes its plugin APIs and other
-    // useful information. In this case, we use it to listen to the microphone's UI state, which
-    // we can use to show some UI conditional on this state.
-    onState = { state ->
-        state.onUIState {
-            print(it)
+        // Anonymous objects allow us to create a plugin without having to create a new class,
+        // thereby giving access to our view's state.
+        object : AttendiMicrophonePlugin {
+            override fun activate(state: AttendiMicrophoneState) {
+                state.onUIState {
+                    microphoneUIState = it
+                }
+            }
         }
-    },
+    ),
     // Use `onEvent` to listen to arbitrary events
     onEvent = { name, data ->
         when (name) {

--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendimicrophone/AttendiMicrophone.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendimicrophone/AttendiMicrophone.kt
@@ -140,11 +140,6 @@ val LocalMicrophoneState =
  * this attribute to `true`.
  * @param showOptions Currently not used. If set to `true`, the component will expand to show an options button.
  * When clicked, an options menu is shown in a bottom sheet.
- * @param onState Use this callback to access the [AttendiMicrophoneState] of the microphone. This
- * can be used to access the microphone's state, such as the current UI state, or to register
- * callbacks that are called when the microphone's state changes. This is an alternative to
- * using the [AttendiMicrophonePlugin] interface, allowing simpler access to the microphone's
- * plugin interface.
  * @param onEvent This callback allows plugins to send arbitrary events to the [AttendiMicrophone]'s
  * caller. This can be useful when the result is not just a string, but an arbitrary
  * data structure. The caller can branch on the event name to handle the event(s) it
@@ -164,7 +159,6 @@ fun AttendiMicrophone(
     plugins: List<AttendiMicrophonePlugin> = listOf(),
     silent: Boolean = false,
     showOptions: Boolean = false,
-    onState: (state: AttendiMicrophoneState) -> Unit = { _ -> },
     onEvent: (name: String, Any) -> Unit = { _, _ -> },
     onResult: (String) -> Unit = { },
 ) {
@@ -241,9 +235,6 @@ fun AttendiMicrophone(
         allPlugins.forEach { plugin ->
             plugin.activate(microphoneState)
         }
-
-        // Give callers access to the microphone state
-        onState(microphoneState)
     }
 
     // Deactivate plugins when the microphone leaves the composition

--- a/attendispeechserviceexample/src/main/java/nl/attendi/attendispeechserviceexample/MainActivity.kt
+++ b/attendispeechserviceexample/src/main/java/nl/attendi/attendispeechserviceexample/MainActivity.kt
@@ -57,8 +57,10 @@ import androidx.compose.ui.unit.dp
 import nl.attendi.attendispeechservice.client.ModelType
 import nl.attendi.attendispeechservice.client.TranscribeAPIConfig
 import nl.attendi.attendispeechservice.components.attendimicrophone.AttendiMicrophone
+import nl.attendi.attendispeechservice.components.attendimicrophone.AttendiMicrophoneState
 import nl.attendi.attendispeechservice.components.attendimicrophone.MicrophoneUIState
 import nl.attendi.attendispeechservice.components.attendimicrophone.plugins.AttendiErrorPlugin
+import nl.attendi.attendispeechservice.components.attendimicrophone.plugins.AttendiMicrophonePlugin
 import nl.attendi.attendispeechservice.components.attendimicrophone.plugins.AttendiTranscribePlugin
 import nl.attendi.attendispeechserviceexample.ui.theme.AttendiSpeechServiceExampleTheme
 
@@ -253,12 +255,14 @@ fun HoveringMicrophoneScreen() {
                 plugins = listOf(
                     AttendiErrorPlugin(),
                     AttendiTranscribePlugin(apiConfig = exampleAPIConfig),
-                ),
-                onState = { state ->
-                    state.onUIState {
-                        microphoneUIState = it
+                    object : AttendiMicrophonePlugin {
+                        override fun activate(state: AttendiMicrophoneState) {
+                            state.onUIState {
+                                microphoneUIState = it
+                            }
+                        }
                     }
-                },
+                ),
                 onResult = {
                     when (focusedTextField) {
                         1 -> text1 = addParagraph(text1, it)


### PR DESCRIPTION
The same functionality can be achieved by using an anonymous class in the `plugins` parameter. Since we don't need it, we can remove the `onState` parameter.