### PR TITLE
feat: smoother volume feedback

### DIFF
--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendimicrophone/AttendiMicrophone.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendimicrophone/AttendiMicrophone.kt
@@ -36,6 +36,7 @@ import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
@@ -739,7 +740,7 @@ class AttendiMicrophoneState @OptIn(ExperimentalMaterial3Api::class) constructor
         isDialogOpen = true
     }
 
-    // ========== Animateable elements ==========
+    // ========== Animatable elements ==========
 
     private var _animatedMicrophoneFillLevel by mutableStateOf(0.0)
 
@@ -941,13 +942,19 @@ fun RecordingView() {
             val microphoneFillPercentage =
                 startYPercentage - (startYPercentage - endYPercentage) * microphoneState.animatedMicrophoneFillLevel
 
+            // Make the animation a bit smoother by tweening between the current and the target value
+            val animatedMicrophoneFillPercentage: Float by animateFloatAsState(
+                targetValue = microphoneFillPercentage.toFloat(), animationSpec = tween(150),
+                label = "attendiMicrophoneFillPercentage"
+            )
+
             // Microphone volume fill
             Canvas(modifier = Modifier.fillMaxSize()) {
                 drawLine(
                     color = foregroundColor,
                     start = Offset((0.5 * maxWidth).toPx(), (0.61 * maxHeight).toPx()),
                     end = Offset(
-                        (0.5 * maxWidth).toPx(), (microphoneFillPercentage * maxHeight).toPx()
+                        (0.5 * maxWidth).toPx(), (animatedMicrophoneFillPercentage * maxHeight).toPx()
                     ),
                     strokeWidth = (0.33 * maxWidth).toPx(),
                 )

--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendimicrophone/plugins/VolumeFeedbackPlugin.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendimicrophone/plugins/VolumeFeedbackPlugin.kt
@@ -31,7 +31,7 @@ class VolumeFeedbackPlugin : AttendiMicrophonePlugin {
             val alpha = getMovingAverageAlpha(it)
             volume = (1 - alpha) * volume + alpha * it
 
-            val normalizedVolume = normalizeVolume(volume).pow(0.2)
+            val normalizedVolume = normalizeVolume(volume)
 
             // We want to always scale the volume feedback by at least this factor of the maximum size
             // This means that the volume feedback will always be visible,
@@ -79,7 +79,7 @@ fun getMovingAverageAlpha(currentVolume: Double): Double {
  * Hand tuned to give good values for the microphone volume, such that the value is 0 when
  * not talking, and 1 when talking at a normal volume.
  *
- * During testing, observed values were around 300 when no speaking occurred, with speaking volume up
- * to 8000 - 10000.
+ * During testing, observed values were around 700 when no speaking occurred, with speaking volume up
+ * to 3000-5000.
  */
-fun normalizeVolume(audioLevel: Double) = ((audioLevel - 400) / 3000).coerceIn(0.0, 1.0)
+fun normalizeVolume(audioLevel: Double) = ((audioLevel - 800) / 2400).coerceIn(0.0, 1.0).pow(0.25)


### PR DESCRIPTION
The volume feedback within the microphone was a bit janky. To mitigate this, we animate between the microphone fill percentage.

We also adjust the volume normalization parameters a little bit, as the displayed volume seemed a bit too high overall.

Before <-> after

<div style="display: flex;">
<img src="https://github.com/attenditechnology/attendi-android/assets/145569813/e64b1eb7-b6a8-4d94-875e-8165a53c4cb6" width="400">
<img src="https://github.com/attenditechnology/attendi-android/assets/145569813/e69f778a-856e-450f-a2b3-7ac318f95075" width="400">
</div>

