### PR TITLE
fix: play audio after rotations and more careful audio plugin registration

### DIFF
--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendimicrophone/AttendiMicrophone.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendimicrophone/AttendiMicrophone.kt
@@ -219,8 +219,8 @@ fun AttendiMicrophone(
 
     // Used to launch activities, such as going to the settings to grant the microphone permission.
     val launcher = rememberLauncherForActivityResult(
-        ActivityResultContracts.StartActivityForResult(),
-        onResult = {})
+            ActivityResultContracts.StartActivityForResult(),
+            onResult = {})
 
     // Used so we can fire a callback only on the first interaction with the microphone.
     var firstClickHappened by rememberSaveable { mutableStateOf(false) }
@@ -261,11 +261,14 @@ fun AttendiMicrophone(
         }
     }
 
-    val defaultPlugins = listOf(
-        AudioNotificationPlugin(),
-        VolumeFeedbackPlugin(),
-    )
-    val allPlugins = defaultPlugins + plugins
+    val allPlugins = remember {
+        val defaultPlugins = listOf(
+            AudioNotificationPlugin(),
+            VolumeFeedbackPlugin(),
+        )
+
+        defaultPlugins + plugins
+    }
 
     LaunchedEffect(Unit) {
         allPlugins.forEach { plugin ->
@@ -302,12 +305,6 @@ fun AttendiMicrophone(
             }
         }
     }
-
-    // Keeps track of whether the recording was interrupted by lifecycle events such as backgrounding or rotation.
-    // This is used to resume recording when the app is foregrounded again. We need it since
-    // `Lifecycle.Event.ON_RESUME` is also called when the composable enters the view, and doesn't
-    // necessarily mean that the recording was interrupted
-    var recordingInterruptedByLifecycle by rememberSaveable { mutableStateOf(false) }
 
     // Handle backgrounding and foregrounding of the app. The current intended behavior is that
     // recording is paused when the app is backgrounded, and resumed when the app is foregrounded.

--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendimicrophone/plugins/AudioNotificationPlugin.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendimicrophone/plugins/AudioNotificationPlugin.kt
@@ -37,9 +37,13 @@ class AudioNotificationPlugin : AttendiMicrophonePlugin {
     override fun activate(state: AttendiMicrophoneState) {
         if (state.silent) return
 
-        state.onFirstClick {
+        if (startNotificationSound == null) {
             startNotificationSound = MediaPlayer.create(state.context, R.raw.start_notification)
+        }
+        if (stopNotificationSound == null) {
             stopNotificationSound = MediaPlayer.create(state.context, R.raw.stop_notification)
+        }
+        if (errorNotificationSound == null) {
             errorNotificationSound = MediaPlayer.create(state.context, R.raw.error_notification)
         }
 
@@ -90,5 +94,9 @@ class AudioNotificationPlugin : AttendiMicrophonePlugin {
         startNotificationSound?.release()
         stopNotificationSound?.release()
         errorNotificationSound?.release()
+
+        startNotificationSound = null
+        stopNotificationSound = null
+        errorNotificationSound = null
     }
 }


### PR DESCRIPTION
Before, the audio notification plugin would not play audio after rotations. This happened since the sounds would be loaded on the first click. However, since we currently keep track of the first click with `rememberSaveable`, the callback that loads the sounds is not executed on configuration changes such as rotation. Since the the audio notification plugin _is_ re-activated on rotations but the first click is persisted, the sounds are not loaded the second time around. We now circumvent this by loading the sounds directly in the `activate` function.