### PR TITLE
chore: add github meta files like issue templates

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in our community a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+* Showing empathy and kindness
+* Being respectful of differing viewpoints
+
+Examples of unacceptable behavior include:
+* Insulting or derogatory comments
+* Publishing others’ private information
+
+## Enforcement Responsibilities
+
+Maintainers are responsible for clarifying and enforcing standards.
+
+## Scope
+
+This Code applies in all community spaces and when representing the project.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,19 +4,22 @@ Currently, the team maintaining this repo is small and time-constrained. While w
 contributions, we can't guarantee a timely response to every pull request or issue. We will review
 these on a best-effort basis.
 
-
 ## Development Principles
+
 - Keep PRs focused and under 300 LOC when possible.
-- Add or update **unit tests** for every bug fix or feature.
+- Add or update **unit tests** whenever possible.
 - Document public APIs in Kotlin docstrings.
 - **Commit** using Conventional Commits (e.g., `feat(recorder): add onBeforeStart callback API`).
 - **Open a Pull Request** against `main` and fill in the PR template.
+- Ensure that the project and its unit tests compile and run correctly.
 
 ## Issue Reporting
+
 When filing an issue, please:
 - Use the **Bug Report** or **Feature Request** template.
 - Include reproduction steps or a failing test if applicable.
 - Be respectful and follow our Code of Conduct.
 
 ## License
+
 By contributing you agree your work is released under this repository’s license.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing
+
+Currently, the team maintaining this repo is small and time-constrained. While we appreciate all
+contributions, we can't guarantee a timely response to every pull request or issue. We will review
+these on a best-effort basis.
+
+
+## Development Principles
+- Keep PRs focused and under 300 LOC when possible.
+- Add or update **unit tests** for every bug fix or feature.
+- Document public APIs in Kotlin docstrings.
+- **Commit** using Conventional Commits (e.g., `feat(recorder): add onBeforeStart callback API`).
+- **Open a Pull Request** against `main` and fill in the PR template.
+
+## Issue Reporting
+When filing an issue, please:
+- Use the **Bug Report** or **Feature Request** template.
+- Include reproduction steps or a failing test if applicable.
+- Be respectful and follow our Code of Conduct.
+
+## License
+By contributing you agree your work is released under this repository’s license.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,36 @@
+name: "🐛 Bug report"
+description: Create a report to help us improve
+title: "[Bug]: "
+labels: ["bug", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please complete the form below.
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps To Reproduce
+      description: How can we reproduce the issue?
+      placeholder: |
+        1. Go to '...'
+        2. Run '...'
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version/Commit SHA

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: "✨ Feature request"
+description: Suggest an idea for this project
+title: "[Feature]: "
+labels: ["enhancement", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a cool idea? Let us know!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem would this feature solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Solution
+      placeholder: Describe how you’d like it to work.
+    validations:
+      required: true
+  - type: input
+    id: alternatives
+    attributes:
+      label: Alternatives Considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Checklist
+- [ ] Title follows Conventional Commits
+- [ ] Lint & tests pass locally
+- [ ] Docs updated (if needed)
+- [ ] Linked to an open issue
+
+## Description
+<!-- Describe what this PR does and why -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | ✅        |
+| < latest| ❌        |
+
+## Reporting a Vulnerability
+
+Please email **security [at] attendi [dot] nl** with:
+* A description of the flaw
+* Steps to reproduce
+* Your PGP public key (optional)
+
+Do **not** create public GitHub issues for security problems.


### PR DESCRIPTION
Added
- bug report, feature request templates for issues
- code of conduct
- contributing guidelines
- pull request template
- security guidelines