### PR TITLE
Downgrade kotlin to 2.0.10 and sdk to 34

### DIFF
--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/utils/VerifyAudioPermissionView.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/utils/VerifyAudioPermissionView.kt
@@ -8,10 +8,10 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.core.app.ActivityCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.compose.LocalLifecycleOwner
 
 /**
  * Represents the current status of the audio recording permission.

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ buildscript {
         project_version = "0.3.1"
 
         // App targets
-        compile_sdk_version = 35
-        target_sdk_version = 35
+        compile_sdk_version = 34
+        target_sdk_version = 34
         min_sdk_version = 26
 
         // Java
@@ -16,17 +16,17 @@ buildscript {
         jvm_target_version = 17
 
         // JetPack Compose
-        compose_bom_version = '2025.06.01'
-        activity_compose_version = '1.10.1'
-        viewmodel_compose_version = '2.9.1'
-        navigation_compose_version = '2.9.1'
+        compose_bom_version = '2024.06.00'
+        activity_compose_version = '1.9.3'
+        viewmodel_compose_version = '2.8.7'
+        navigation_compose_version = '2.8.9'
 
         // Essentials
-        core_ktx_version = '1.16.0'
+        core_ktx_version = '1.13.1'
 
         // Networking & Serialization
-        okhttp_version = '5.1.0'
-        serialization_json_version = '1.9.0'
+        okhttp_version = '4.12.0'
+        serialization_json_version = '1.8.1'
 
         // Testing
         junit_version = '4.13.2'
@@ -44,7 +44,7 @@ buildscript {
 plugins {
     id 'com.android.application' version '8.12.0' apply false
     id 'com.android.library' version '8.12.0' apply false
-    id 'org.jetbrains.kotlin.android' version '2.2.0' apply false
-    id 'org.jetbrains.kotlin.plugin.compose' version "2.2.0" apply false
-    id 'org.jetbrains.kotlin.plugin.serialization' version '2.2.0' apply false
+    id 'org.jetbrains.kotlin.android' version '2.0.10' apply false
+    id 'org.jetbrains.kotlin.plugin.compose' version "2.0.10" apply false
+    id 'org.jetbrains.kotlin.plugin.serialization' version '2.0.10' apply false
 }


### PR DESCRIPTION
## Checklist
- [ ] Title follows Conventional Commits
- [X] Lint & tests pass locally
- [ ] Docs updated (if needed)
- [ ] Linked to an open issue

## Description
Since our project does not yet conform to sdk 35 and kotlin 2.2.0 with this pr we propose downgrading them (and all the related dependencies) until the upgrade extension from Google (November 2025) expires.

Changes in this pr:
- Downgrade kotlin to 2.0.10
- Downgrade sdk to 34
- Downgrade compose bom to 2024.06.00
- Downgrade libraries that require sdk 35

