### PR TITLE
Dispatch to Main Thread onStart and onStop callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3 - 2025-08-15]
+### Improved
+- [AttendiRecorderModel.onStartRecording] and [AttendiRecorderModel.onStopRecording] callbacks are now automatically dispatched to the Main Thread. 
+  This ensures that UI updates inside these callbacks are safe and prevents `CalledFromWrongThreadException`.
+
+Before this change:
+```kotlin
+override suspend fun activate(model: AttendiRecorderModel) {
+    model.onStartRecording {
+        withContext(Dispatchers.Main) {
+            // Perform UI update safely.
+        } 
+      /**
+       * Updating the UI outside the Main Thread would throw:
+       * `android.view.ViewRootImpl$CalledFromWrongThreadException: Only the original thread that created a view hierarchy can touch its views.`
+       */
+    }
+}
+```
+After this change:
+```kotlin
+override suspend fun activate(model: AttendiRecorderModel) {
+    model.onStartRecording {
+      // Perform UI update safely without manual Main Thread dispatch.
+    }
+}
+```
+
 ## [0.3.2 - 2025-08-15]
+### Changed
 - Downgraded Kotlin from 2.2.0 -> 2.0.10 and SDK from 35 -> 34 to maintain compatibility for projects not yet migrated to the latest versions.
 
 ## [0.3.1 - 2025-08-12]

--- a/README.md
+++ b/README.md
@@ -177,6 +177,34 @@ class AttendiAsyncTranscribePlugin(private val service: AsyncTranscribeService) 
 }
 ```
 
+## Hooks Available on AttendiRecorderModel
+
+Plugins can subscribe to a variety of callbacks on AttendiRecorderModel to observe or modify behavior. Be aware of the threading contract for each callback:
+* Main Thread (Safe to update the UI)
+These callbacks are automatically dispatched on the Main Thread, making it safe to modify the view hierarchy directly:
+    - AttendiRecorderModel.onStartRecording
+    - AttendiRecorderModel.onStopRecording
+
+* Background Thread (Not safe to update the UI directly)
+These callbacks are dispatched on a background thread for performance reasons.
+    - AttendiRecorderModel.onBeforeStartRecording
+    - AttendiRecorderModel.onBeforeStopRecording
+    - AttendiRecorderModel.onAudio
+    - AttendiRecorderModel.onError
+    - AttendiRecorderModel.onStateUpdate
+Directly updating the UI here will throw:
+```kotlin
+android.view.ViewRootImpl$CalledFromWrongThreadException: 
+Only the original thread that created a view hierarchy can touch its views.
+```
+
+Tip: To safely update the UI from these callbacks, switch to the main thread:
+```kotlin
+withContext(Dispatchers.Main) {
+    myTextView.text = "Recording..."
+}
+```
+
 ## API Services
 
 The Attendi SDK provides three core service interfaces to communicate with Attendi's backend systems or your own custom infrastructure:

--- a/attendispeechserviceexample/src/main/java/nl/attendi/attendispeechserviceexample/MainActivity.kt
+++ b/attendispeechserviceexample/src/main/java/nl/attendi/attendispeechserviceexample/MainActivity.kt
@@ -123,7 +123,7 @@ fun ExampleApp() {
 
         NavHost(
             navController = rootNavController,
-            startDestination = InternalRoute.TWO_MICROPHONES_STREAMING,
+            startDestination = currentScreen,
             route = InternalRoute.MAIN_ROUTE
         ) {
             composable(route = InternalRoute.TWO_MICROPHONES_STREAMING) {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
      */
     ext {
         // Project Version
-        project_version = "0.3.2"
+        project_version = "0.3.3"
 
         // App targets
         compile_sdk_version = 34


### PR DESCRIPTION
Ticket: AT-4104

## Checklist
- [X] Title follows Conventional Commits
- [X] Lint & tests pass locally
- [X] Docs updated (if needed)
- [X] Linked to an open issue (Reported internally)

## Description
[AttendiRecorderModel.onStartRecording] and [AttendiRecorderModel.onStopRecording] callbacks are now automatically dispatched to the Main Thread.
This ensures that UI updates inside these callbacks are safe and prevents `CalledFromWrongThreadException`.