### PR TITLE
Fix Composable preview crash in UI Components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5 - 2025-09-01]
+### Fixed
+- Composable Preview crashes when previewing certain UI components:
+1. VerifyAudioPermissionView
+2. AudioPermissionDeniedPermanentlyDialog (from AttendiMicrophone)
+The crashes were caused by casting LocalContext.current directly to Activity:
+```kotlin
+val activity = context as Activity
+```
+In Android Studio previews, LocalContext.current returns a BridgeContext instead of an actual Activity. 
+The fix uses a safe cast (as? Activity) and handles the null case, making previews render safely without affecting runtime behavior.
+
 ## [0.3.4 - 2025-09-01]
 ### Fixed
 - Memory leak caused by holding a reference to context in the following plugins:

--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendimicrophone/microphone/AttendiMicrophone.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendimicrophone/microphone/AttendiMicrophone.kt
@@ -183,7 +183,7 @@ fun AttendiMicrophone(
 @Composable
 private fun AudioPermissionDeniedPermanentlyDialog(onDismiss: () -> Unit) {
     val context = LocalContext.current
-    val activity = context as Activity
+    val activity = context as? Activity
 
     vibrate(context)
     AlertDialog(
@@ -194,9 +194,9 @@ private fun AudioPermissionDeniedPermanentlyDialog(onDismiss: () -> Unit) {
             TextButton(onClick = {
                 // Open app settings.
                 val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                    data = Uri.fromParts("package", activity.packageName, null)
+                    data = Uri.fromParts("package", activity?.packageName, null)
                 }
-                activity.startActivity(intent)
+                activity?.startActivity(intent)
                 onDismiss()
             }) {
                 Text(context.getString(R.string.noMicrophone_permission_dialog_goToSettings_button))

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
      */
     ext {
         // Project Version
-        project_version = "0.3.4"
+        project_version = "0.3.5"
 
         // App targets
         compile_sdk_version = 34


### PR DESCRIPTION
Ticket: AT-4104

## Checklist
- [X] Title follows Conventional Commits
- [X] Lint & tests pass locally
- [X] Docs updated (if needed)
- [ ] Linked to an open issue

## Description
Fix Composable preview crash caused by activity cast from context in the following views:
1. VerifyAudioPermissionView
2. AudioPermissionDeniedPermanentlyDialog (from AttendiMicrophone)