### PR TITLE
Revert version upgrade to keep compile sdk 34 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,12 +17,12 @@ buildscript {
 
         // JetPack Compose
         compose_bom_version = '2024.06.00'
-        activity_compose_version = '1.10.1'
+        activity_compose_version = '1.9.3'
         viewmodel_compose_version = '2.8.7'
-        navigation_compose_version = '2.9.3'
+        navigation_compose_version = '2.8.9'
 
         // Essentials
-        core_ktx_version = '1.17.0'
+        core_ktx_version = '1.13.1'
 
         // Networking & Serialization
         okhttp_version = '5.1.0'


### PR DESCRIPTION
Ticket: AT-4104

## Checklist
- [X] Title follows Conventional Commits
- [X] Lint & tests pass locally
- [X] Docs updated (if needed)
- [ ] Linked to an open issue

## Description
Revert version upgrade to keep compile sdk 34 compatibility on the following dependencies:
- activity_compose
- navigation_compose
- core_ktx