### PR TITLE
Revert plugins to make it compatible with SDK 34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6 - 2025-09-02]
+### Changed
+- Downgraded Kotlin from 2.2.0 -> 2.0.10 and SDK from 35 -> 34 again to ensure compatibility with projects that have not yet migrated. 
+  This reverts the reintroduction of newer versions in 0.3.5.
+
 ## [0.3.5 - 2025-09-01]
 ### Fixed
 - Composable Preview crashes when previewing certain UI components:

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
      */
     ext {
         // Project Version
-        project_version = "0.3.5"
+        project_version = "0.3.6"
 
         // App targets
         compile_sdk_version = 34
@@ -42,9 +42,9 @@ buildscript {
  * Modular builds: You apply the plugin only where needed.
  */
 plugins {
-    id 'com.android.application' version '8.12.2' apply false
-    id 'com.android.library' version '8.12.2' apply false
-    id 'org.jetbrains.kotlin.android' version '2.2.10' apply false
-    id 'org.jetbrains.kotlin.plugin.compose' version "2.2.10" apply false
-    id 'org.jetbrains.kotlin.plugin.serialization' version '2.2.10' apply false
+    id 'com.android.application' version '8.12.0' apply false
+    id 'com.android.library' version '8.12.0' apply false
+    id 'org.jetbrains.kotlin.android' version '2.0.10' apply false
+    id 'org.jetbrains.kotlin.plugin.compose' version "2.0.10" apply false
+    id 'org.jetbrains.kotlin.plugin.serialization' version '2.0.10' apply false
 }


### PR DESCRIPTION
Ticket: AT-4104

## Checklist
- [X] Title follows Conventional Commits
- [X] Lint & tests pass locally
- [X] Docs updated (if needed)
- [ ] Linked to an open issue

## Description
- Downgraded Kotlin from 2.2.0 -> 2.0.10 and SDK from 35 -> 34 again to ensure compatibility with projects that have not yet migrated. This reverts the reintroduction of newer versions in 0.3.5.