### PR TITLE
Revert OkHttp version that forces kotlin version upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         core_ktx_version = '1.13.1'
 
         // Networking & Serialization
-        okhttp_version = '5.1.0'
+        okhttp_version = '4.12.0'
         serialization_json_version = '1.8.1'
 
         // Testing


### PR DESCRIPTION
Ticket: AT-4104

## Checklist
- [X] Title follows Conventional Commits
- [X] Lint & tests pass locally
- [X] Docs updated (if needed)
- [ ] Linked to an open issue

## Description
Fixes issue:
Class 'okhttp3.Request' was compiled with an incompatible version of Kotlin. The actual metadata version is 2.2.0, but the compiler version 2.0.0 can read versions up to 2.1.0.