### PR TITLE
Fix AttendiAsyncTranscribePlugin UI update and AsyncTranscribeService Retry mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.7 - 2025-09-29]
+### Changed
+- `AttendiAsyncTranscribePlugin` now connects to the WebSocket in `onBeforeStartRecording` instead of `onStartRecording`.
+  This ensures that the `AttendiMicrophone` component remains in the loading state until the WebSocket connection is fully established, improving UI consistency and user feedback.
+- `BaseAsyncTranscribeService` now allows consumers create their custom OkHttpClient for establishing the WebSocket connection.
+
+### Fixed
+- Race condition issue where stopping a recording and immediately starting a new one could leave the `AttendiMicrophone` in an incorrect UI state.
+- `AsyncTranscribeService` retry mechanism where the retry logic would not continue properly after a successful retry attempt.
+
+### Fixed
+- Downgraded Kotlin from 2.2.0 -> 2.0.10 and SDK from 35 -> 34 again to ensure compatibility with projects that have not yet migrated.
+  This reverts the reintroduction of newer versions in 0.3.5.
+
 ## [0.3.6 - 2025-09-02]
 ### Changed
 - Downgraded Kotlin from 2.2.0 -> 2.0.10 and SDK from 35 -> 34 again to ensure compatibility with projects that have not yet migrated. 

--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendirecorder/plugins/asynctranscribeplugin/AttendiAsyncTranscribePlugin.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendirecorder/plugins/asynctranscribeplugin/AttendiAsyncTranscribePlugin.kt
@@ -92,10 +92,10 @@ class AttendiAsyncTranscribePlugin(
      * Starts sending audio when enough buffered samples are collected.
      */
     override suspend fun activate(model: AttendiRecorderModel) {
-        model.onStartRecording {
+        model.onBeforeStartRecording {
             stateMutex.withLock {
                 if (isStreamConnecting) {
-                    return@onStartRecording
+                    return@onBeforeStartRecording
                 }
                 isStreamConnecting = true
 

--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendirecorder/recorder/AttendiRecorderImpl.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendirecorder/recorder/AttendiRecorderImpl.kt
@@ -172,17 +172,22 @@ internal class AttendiRecorderImpl(
             model.callbacks.onBeforeStartRecording.invokeAll()
 
             recorderJob = internalScope.launch {
-                delay(delayMilliseconds)
-                handleErrors {
-                    recorder.startRecording(
-                        audioRecordingConfig = audioRecordingConfig,
-                        onAudio = { audioFrame ->
-                            model.callbacks.onAudio.invokeAll(audioFrame)
+                startStopMutex.withLock {
+                    if (!hasStarted || isReleased) {
+                        return@withLock
+                    }
+                    delay(delayMilliseconds)
+                    handleErrors {
+                        recorder.startRecording(
+                            audioRecordingConfig = audioRecordingConfig,
+                            onAudio = { audioFrame ->
+                                model.callbacks.onAudio.invokeAll(audioFrame)
+                            }
+                        )
+                        model.updateState(AttendiRecorderState.Recording)
+                        withContext(callbackDispatcher) {
+                            model.callbacks.onStartRecording.invokeAll()
                         }
-                    )
-                    model.updateState(AttendiRecorderState.Recording)
-                    withContext(callbackDispatcher) {
-                        model.callbacks.onStartRecording.invokeAll()
                     }
                 }
             }

--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/services/asynctranscribe/AttendiAsyncTranscribeServiceFactory.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/services/asynctranscribe/AttendiAsyncTranscribeServiceFactory.kt
@@ -14,14 +14,18 @@ object AttendiAsyncTranscribeServiceFactory {
      * This service manages the WebSocket connection, authentication, and audio streaming.
      *
      * @param apiConfig Configuration for authentication and endpoint setup.
+     * @param accessToken Optional pre-obtained access token. If provided, it will be used directly for
+     * authentication instead of requesting a new token from the authentication service.
      * @return A fully configured instance of [AsyncTranscribeService].
      */
     fun create(
-        apiConfig: AttendiTranscribeAPIConfig
+        apiConfig: AttendiTranscribeAPIConfig,
+        accessToken: String? = null
     ): AsyncTranscribeService {
         return AttendiAsyncTranscribeServiceImpl(
             apiConfig = apiConfig,
-            authenticationService = AttendiAuthenticationServiceImpl
+            authenticationService = AttendiAuthenticationServiceImpl,
+            accessToken = accessToken
         )
     }
 }

--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/services/asynctranscribe/AttendiAsyncTranscribeServiceImpl.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/services/asynctranscribe/AttendiAsyncTranscribeServiceImpl.kt
@@ -28,7 +28,7 @@ import okhttp3.Request
 internal class AttendiAsyncTranscribeServiceImpl(
     private val apiConfig: AttendiTranscribeAPIConfig,
     private val authenticationService: AttendiAuthenticationService,
-    private val accessToken: String? = null
+    private var accessToken: String? = null
 ) : BaseAsyncTranscribeService() {
 
     private companion object {
@@ -38,6 +38,7 @@ internal class AttendiAsyncTranscribeServiceImpl(
 
     override suspend fun createWebSocketRequest(): Request {
         val accessToken = accessToken ?: authenticationService.authenticate(apiConfig = apiConfig)
+        this.accessToken = accessToken
         return createAttendiWebSocketRequest(accessToken)
     }
 

--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/services/asynctranscribe/AttendiAsyncTranscribeServiceImpl.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/services/asynctranscribe/AttendiAsyncTranscribeServiceImpl.kt
@@ -2,6 +2,7 @@ package nl.attendi.attendispeechservice.services.asynctranscribe
 
 import nl.attendi.attendispeechservice.services.AttendiTranscribeAPIConfig
 import nl.attendi.attendispeechservice.services.authentication.AttendiAuthenticationService
+import okhttp3.OkHttpClient
 import okhttp3.Request
 
 /**

--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/services/asynctranscribe/BaseAsyncTranscribeService.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/services/asynctranscribe/BaseAsyncTranscribeService.kt
@@ -182,6 +182,7 @@ abstract class BaseAsyncTranscribeService : AsyncTranscribeService {
         } catch (e: Exception) {
             if (retryCount == 0) {
                 listener.onError(AsyncTranscribeServiceError.Unknown(e.message))
+                handleSocketClosed()
             } else {
                 connectSocket(
                     listener,
@@ -221,10 +222,6 @@ abstract class BaseAsyncTranscribeService : AsyncTranscribeService {
                     }
 
                     override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
-                        listener?.onError(
-                            AsyncTranscribeServiceError.Unknown(message = response?.message)
-                        )
-                        handleSocketClosed()
                         if (continuation.isActive) continuation.resumeWithException(t)
                     }
                 })

--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/services/asynctranscribe/BaseAsyncTranscribeService.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/services/asynctranscribe/BaseAsyncTranscribeService.kt
@@ -32,6 +32,10 @@ import kotlin.coroutines.resumeWithException
  * - [getOpenMessage]: to send a configuration payload upon connection.
  * - [getCloseMessage] and [getCloseCode]: to customize socket shutdown behavior.
  *
+ * A custom [OkHttpClient] can also be provided by overriding [createWebSocketClient],
+ * allowing control over timeouts, interceptors, TLS settings, or other client-level
+ * WebSocket configurations.
+ *
  * This base class is designed to be extended by service implementations targeting specific
  * WebSocket-based transcription backends, while abstracting away connection boilerplate.
  */
@@ -62,9 +66,17 @@ abstract class BaseAsyncTranscribeService : AsyncTranscribeService {
     private val connectMutex = Mutex()
     private var socket: WebSocket? = null
     private var listener: AsyncTranscribeServiceListener? = null
-    private val webSocketClient = OkHttpClient()
     private var isConnected = false
     private var isDisconnecting = false
+
+    /**
+     * Creates and configures the [OkHttpClient] instance used for establishing the WebSocket connection.
+     *
+     * @return A configured [OkHttpClient] ready to be used for WebSocket communication.
+     */
+    protected open fun createWebSocketClient(): OkHttpClient {
+        return OkHttpClient()
+    }
 
     /**
      * Creates the WebSocket [Request] object used to initiate the connection.
@@ -198,7 +210,7 @@ abstract class BaseAsyncTranscribeService : AsyncTranscribeService {
     private suspend fun connectSocket(request: Request) {
         withTimeout(CONNECTION_TIMEOUT_MILLISECONDS) {
             suspendCancellableCoroutine { continuation ->
-                socket = webSocketClient.newWebSocket(request, object : WebSocketListener() {
+                socket = createWebSocketClient().newWebSocket(request, object : WebSocketListener() {
                     override fun onOpen(webSocket: WebSocket, response: Response) {
                         getOpenMessage()?.let { configMessage ->
                             webSocket.send(configMessage)

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
      */
     ext {
         // Project Version
-        project_version = "0.3.6"
+        project_version = "0.3.7"
 
         // App targets
         compile_sdk_version = 34


### PR DESCRIPTION
## Checklist
- [X] Title follows Conventional Commits
- [X] Lint & tests pass locally
- [X] Docs updated (if needed)
- [X] Linked to an open issue

## Description

### Changed
- `AttendiAsyncTranscribePlugin` now connects to the WebSocket in `onBeforeStartRecording` instead of `onStartRecording`.
  This ensures that the `AttendiMicrophone` component remains in the loading state until the WebSocket connection is fully established, improving UI consistency and user feedback.
- `BaseAsyncTranscribeService` now allows consumers create their custom OkHttpClient for establishing the WebSocket connection.

### Fixed
- Race condition issue where stopping a recording and immediately starting a new one could leave the `AttendiMicrophone` in an incorrect UI state.
- `AsyncTranscribeService` retry mechanism where the retry logic would not continue properly after a successful retry attempt.