### PR TITLE
Fix deadlock when calling onStart and onStop when recording is already happening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.8 - 2025-10-01]
+### Fixed
+- A deadlock issue that could occur when onStart or onStop were called from a plugin while a recording was already in progress.
+
 ## [0.3.7 - 2025-09-29]
 ### Changed
 - `AttendiAsyncTranscribePlugin` now connects to the WebSocket in `onBeforeStartRecording` instead of `onStartRecording`.
@@ -14,10 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Race condition issue where stopping a recording and immediately starting a new one could leave the `AttendiMicrophone` in an incorrect UI state.
 - `AsyncTranscribeService` retry mechanism where the retry logic would not continue properly after a successful retry attempt.
-
-### Fixed
-- Downgraded Kotlin from 2.2.0 -> 2.0.10 and SDK from 35 -> 34 again to ensure compatibility with projects that have not yet migrated.
-  This reverts the reintroduction of newer versions in 0.3.5.
 
 ## [0.3.6 - 2025-09-02]
 ### Changed

--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendirecorder/plugins/asynctranscribeplugin/AttendiAsyncTranscribePlugin.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendirecorder/plugins/asynctranscribeplugin/AttendiAsyncTranscribePlugin.kt
@@ -57,7 +57,6 @@ class AttendiAsyncTranscribePlugin(
 ) : AttendiRecorderPlugin {
 
     private var transcribeStream = AttendiTranscribeStream()
-    private var streamingBuffer = mutableListOf<Short>()
 
     // Used for ensuring thread safety.
     private val stateMutex = Mutex()
@@ -101,12 +100,16 @@ class AttendiAsyncTranscribePlugin(
 
                 resetPluginState()
                 onStreamConnecting()
-
                 try {
                     val serviceListener = createServiceListener(model = model)
                     service.connect(listener = serviceListener)
                 } catch (exception: Exception) {
-                    forceStopRecording(model, exception)
+                    /// A new coroutine is used to free the mutex and avoid a deadlock in case an error happens immediately after trying to connect.
+                    /// Without a task and calling processStreamCompleted inside this same thread will cause a deadlock.
+                    internalScope.launch {
+                        forceStopRecording(model, exception)
+                        processStreamCompleted()
+                    }
                 }
             }
         }
@@ -170,10 +173,10 @@ class AttendiAsyncTranscribePlugin(
         isConnectionOpen = false
         isClosingConnection = false
         pluginError = null
-        streamingBuffer.clear()
     }
 
     private suspend fun forceStopRecording(model: AttendiRecorderModel, exception: Exception) {
+        pluginError = exception
         model.stop()
         model.callbacks.onError.invokeAll(exception)
     }
@@ -186,8 +189,6 @@ class AttendiAsyncTranscribePlugin(
             isClosingConnection = true
 
             service.disconnect()
-
-            streamingBuffer.clear()
         }
     }
 

--- a/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendirecorder/recorder/AttendiRecorderImpl.kt
+++ b/attendispeechservice/src/main/kotlin/nl/attendi/attendispeechservice/components/attendirecorder/recorder/AttendiRecorderImpl.kt
@@ -124,11 +124,17 @@ internal class AttendiRecorderImpl(
          * overriding them directly when using the plugin, preserving encapsulation and consistency.
          */
         model.onStartCalled = {
-            start()
+            // Launch in a separate coroutine to prevent deadlocks if start() acquires locks or suspends.
+            internalScope.launch {
+                start()
+            }
         }
 
         model.onStopCalled = {
-            stop()
+            // Launch in a separate coroutine to prevent deadlocks if stop() acquires locks or suspends.
+            internalScope.launch {
+                stop()
+            }
         }
 
         internalScope.launch {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
      */
     ext {
         // Project Version
-        project_version = "0.3.7"
+        project_version = "0.3.8"
 
         // App targets
         compile_sdk_version = 34


### PR DESCRIPTION
## Checklist
- [X] Title follows Conventional Commits
- [X] Lint & tests pass locally
- [X] Docs updated (if needed)
- [X] Linked to an open issue

## Description
Fix deadlock when calling onStart and onStop when recording is already happening
